### PR TITLE
bug fix - sweep resume_run

### DIFF
--- a/run_model.py
+++ b/run_model.py
@@ -63,6 +63,8 @@ if __name__ == "__main__":
     else: 
         wandb_run_id = run_id
 
+    resume_training = False
+
     # Possibly reading in a runfile (only exists if we are resuming training)
     run_file_path = f"run_files/{run_id}.runfile"
     if os.path.exists(run_file_path):
@@ -72,11 +74,12 @@ if __name__ == "__main__":
             # the second line in the runfile is the wandb run id (might be different from 
             # the internal run id)
             wandb_run_id = f.readline().strip()
+        resume_training = True
     else:
         resume_num_task_batches = 0
 
     # Setting up logging, config read in and seed setting
-    setup(args.path, run_id, wandb_run_id, resume_num_task_batches, args.offline_mode, args.sweep_agent)
+    setup(args.path, run_id, wandb_run_id, resume_num_task_batches, resume_training, args.offline_mode, args.sweep_agent)
 
     # Initializing the modeling pipeline with configuration and options
     pipeline = Pipeline(run_id, resume_num_task_batches)

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -381,6 +381,7 @@ class Pipeline(object):
         """
 
         self._log_parameters()
+        self._track_training_progress()
 
         ### --------- Inference Mode (no model training) ----------
 

--- a/src/utils/setup.py
+++ b/src/utils/setup.py
@@ -72,6 +72,7 @@ def setup(
     run_id: str,
     wandb_run_id: str,
     resume_num_task_batches: int,
+    resume_training: bool,
     offline_mode: bool,
     sweep_agent: bool,
 ) -> None:
@@ -87,10 +88,10 @@ def setup(
         * run_id: id of the run
         * wandb_run_id: id of the wandb run (possibly NONE)
         * resume_num_task_batches: number of task batches to resume training from
+        * resume_training: whether or not to resume training
         * offline_mode: whether or not to run in offline mode
         * sweep_agent: whether or not the program is being run by a sweep agent
     """
-    resume_training = resume_num_task_batches > 0
 
     # setting the start method to spawn to avoid issues with CUDA and WandB
     try:


### PR DESCRIPTION
when sweep crashed before finishing evaluation, before resume_run would not have been set (because total num tasks was 0) - now changing resume_run to be dependent on reading in resume file